### PR TITLE
Update magCIF.dic

### DIFF
--- a/magCIF.dic
+++ b/magCIF.dic
@@ -2403,31 +2403,19 @@ _type.purpose                           State
 loop_
   _enumeration_set.state
   _enumeration_set.detail
-      'ISOMAG'
+      'ISO(3+d)D-MAG'
 ;
-     This superspace transformation takes the setting of the basic magnetic
-     space group of the magnetic superspace group to the BNS setting of the
-     corresponding magnetic space group in the ISO-MAG tables.  Only the
-     external-space components of the transformation are non-trivial.
-;
-      'ISO(3+d)D'
-;
-     After eliminating all time-reversed operators from the magnetic
-     superspace group, this transformation will take the setting of the
-     resulting non-magnetic superspace-group to the setting of the
-     corresponding entry in the ISO(3+d)D tables.
-;
-      'ISOMAG-ISO(3+d)D'
-;
-     This superspace transformation is the the product of the 'ISO(3+d)D' 
-     and 'ISOMAG' transformations, with the 'ISOMAG' transformation being
-     applied last.  It takes the current setting of the magnetic superspace 
-     group to one where the basic magnetic space group has the setting
-     of the corresponding magnetic space group in the ISO-MAG tables, and
-     where the derived non-magnetic superspace group (obtained by setting
-     all magnetic moments to zero) is related by a purely external operation
-     to the setting of the corresponding superspace group in the ISO(3+d)D tables.
-     Such a transformation is unique for any setting of a magnetic superspace group.
+	This superspace transformation simultaneously takes setting of the 
+	basic magnetic space group (BMSG) to the setting of the corresponding 
+	entry in the ISO-MAG tables, and takes the setting of the
+	derived non-magnetic superspace group (DNMSG) to within a purely external 
+	operation of the setting of the corresponding entry in the ISO(3+d)D tables.
+	The external components of this superspace transformation are those that take
+	the setting of the BMSG to the setting of the corresponding entry
+	in the ISO-MAG tables, while the internal components are those of the
+	transformation that takes the setting of the DNMSG to the setting of the 
+	corresponding superspace group in the ISO(3+d)D tables.  Such a transformation 
+	is unique for any setting of a magnetic superspace group.
 ;
 
 save_
@@ -2520,8 +2508,8 @@ _space_group_magn_transforms.description
 _space_group_magn_transforms.source
 1   'a b c;0 0 0'     .                     "data_block_CURRENT"
 2   'a/2 b c;0 0 0'   "data_block_205763"   .
-3   'a b c;0 0 0'     .                     "ISOMAG_BNS"
-4   'a/2 b c;0 0 0'   .                     "Litvin-2013_OG"
+3   'a b c;0 0 0'     .                     "BNS"
+4   'a/2 b c;0 0 0'   .                     "OG"
 5   'a/4 b  c;0 0 0'  "literature citation to a nuclear parent structure"   .
 ;
 save_

--- a/magCIF.dic
+++ b/magCIF.dic
@@ -1773,8 +1773,8 @@ _description.text
      magnetic structure.
      Analogous tags: symCIF:_space_group_symop.operation_description
      References: 'Magnetic Group Tables' by D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -1828,8 +1828,8 @@ _description.text
      of a magnetic structure.
      Analogous tags: symCIF:_space_group_symop.operation_xyz
      References: 'Magnetic Group Tables' by D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2084,8 +2084,8 @@ _description.text
      MSGs of types 1-3, but differ substantially  for MSGs of type 4.
      Analogous tags: symCIF:_space_group.name_H-M_ref
      References: 'Magnetic Group Tables' by D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2200,8 +2200,8 @@ _description.text
 
      Analogous tags: msCIF:_space_group.ssg_name
      References: ISO-MAG tables of H.T. Stokes and B.J. Campbell at
-     http://iso.byu.edu ISO(3+d)D tables of H.T. Stokes and B.J.
-     Campbell at http://iso.byu.edu
+     http://iso.byu.edu. ISO(3+d)D tables of H.T. Stokes and B.J.
+     Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2265,8 +2265,8 @@ _description.text
      sense here.
      Analogous tags: symCIF:_space_group.number_IT
      References: 'Magnetic Group Tables' by D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2317,8 +2317,8 @@ _description.text
      of types 1-3, but differ substantially  for MSGs of type 4.
      Analogous tags: symCIF:_space_group.name_H-M_ref
      References: 'Magnetic Group Tables' by D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2392,9 +2392,9 @@ _description.text
      If the reference source does not appear in the list below, use
      _space_group_magn_ssg_transforms.description
      References: 'Magnetic Group Tables' of D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu ISO(3+d)D tables
-     of H.T. Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu.
+     ISO(3+d)D tables of H.T. Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2403,22 +2403,31 @@ _type.purpose                           State
 loop_
   _enumeration_set.state
   _enumeration_set.detail
-      'ISOMAG-ISO(3+d)D'
+      'ISOMAG'
 ;
-     a magnetic superspace- group setting such that (1) the setting of
-     the basic magnetic space group matches the corresponding BNS
-     setting in the Magnetic Space Groups tables of Stokes and
-     Campbell, and (2) the non- magnetic superspace-group setting
-     obtained by eliminating all time-reversed operators from the
-     group is related to that of the corresponding setting in the
-     ISO(3+d)D tables via a purely external (three-dimensional)
-     transformation.
+     This superspace transformation takes the setting of the basic magnetic
+     space group of the magnetic superspace group to the BNS setting of the
+     corresponding magnetic space group in the ISO-MAG tables.  Only the
+     external-space components of the transformation are non-trivial.
 ;
       'ISO(3+d)D'
 ;
-     After eliminating all time-reversed operators from the group a
-     non-magnetic superspace-group setting that matches that of the
-     corresponding entry in the ISO(3+d)D tables is obtained
+     After eliminating all time-reversed operators from the magnetic
+     superspace group, this transformation will take the setting of the
+     resulting non-magnetic superspace-group to the setting of the
+     corresponding entry in the ISO(3+d)D tables.
+;
+      'ISOMAG-ISO(3+d)D'
+;
+     This superspace transformation is the the product of the 'ISO(3+d)D' 
+     and 'ISOMAG' transformations, with the 'ISOMAG' transformation being
+     applied last.  It takes the current setting of the magnetic superspace 
+     group to one where the basic magnetic space group has the setting
+     of the corresponding magnetic space group in the ISO-MAG tables, and
+     where the derived non-magnetic superspace group (obtained by setting
+     all magnetic moments to zero) is related by a purely external operation
+     to the setting of the corresponding superspace group in the ISO(3+d)D tables.
+     Such a transformation is unique for any setting of a magnetic superspace group.
 ;
 
 save_
@@ -2559,9 +2568,9 @@ _description.text
      If the reference source does not appear in the list below, use
      _space_group_magn_transforms.description
      References: 'Magnetic Group Tables' of D.B. Litvin at
-     http://www.iucr.org/publ/978-0-9553602-2-0 ISO-MAG tables of H.T.
-     Stokes and B.J. Campbell at http://iso.byu.edu ISO(3+d)D tables
-     of H.T. Stokes and B.J. Campbell at http://iso.byu.edu
+     http://www.iucr.org/publ/978-0-9553602-2-0. ISO-MAG tables of H.T.
+     Stokes and B.J. Campbell at http://iso.byu.edu. ISO(3+d)D tables
+     of H.T. Stokes and B.J. Campbell at http://iso.byu.edu.
 ;
 _type.contents                          Text
 _type.container                         Single
@@ -2577,11 +2586,11 @@ loop_
      current setting can be useful when communicating the same
      magnetic propagation vector in multiple settings.
 ;
-      'ISOMAG-BNS'
+      'BNS'
 ;
      The Belov-Neronova-Smirnova group setting presented in the ISO-MAG tables.
 ;
-      'Litvin-2013_OG'
+      'OG'
 ;
      The Opechowski-Guccione group setting presented in the Magnetic Group Tables of
      D.B. Litvin.


### PR DESCRIPTION
Simplified the prescribed values of the _space_group_magn_transforms.source tag (to BNS and OG).
Substantially edited the explanations associated with the _space_group_magn_ssg_transforms.source tag and added a new value (ISO-MAG).
Minor edits to the references for many transformation-related tags.