### PR TITLE
Quote _type.dimension attribute values

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -221,7 +221,7 @@ _description.text
 ;
 _type.contents                          Integer
 _type.container                         Array
-_type.dimension                         []
+_type.dimension                         '[]'
 save_
 
 ######################
@@ -267,7 +267,7 @@ _description.text
      completing a right-hand set.
 ;
 _type.contents                          Real
-_type.dimension                         [3]
+_type.dimension                         '[3]'
 _type.container                         Matrix
 _type.purpose                           Measurand
 _units.code                             Bohr_magnetons
@@ -365,7 +365,7 @@ _description.text
 ;
 _type.contents                          Real
 _type.container                         Matrix
-_type.dimension                         [3]
+_type.dimension                         '[3]'
 _type.purpose                           Measurand
 _units.code                             Bohr_magnetons
 loop_
@@ -679,7 +679,7 @@ _description.text
      completing a right-hand set.
 ;
 _type.contents                          Real
-_type.dimension                         [3]
+_type.dimension                         '[3]'
 _type.container                         Matrix
 _type.purpose                           Measurand
 _units.code                             radians
@@ -777,7 +777,7 @@ _description.text
 ;
 _type.contents                          Real
 _type.container                         Matrix
-_type.dimension                         [3]
+_type.dimension                         '[3]'
 _type.purpose                           Measurand
 _units.code                             radians
 loop_
@@ -2529,7 +2529,7 @@ _description.text
 ;
 _type.contents                          Real
 _type.container                         Matrix
-_type.dimension                        [3]
+_type.dimension                         '[3]'
 
 save_
 
@@ -2593,7 +2593,7 @@ _description.text
      Analogous tags: symCIF:_space_group.transform_Pp_abc
 ;
 _type.contents                          Real
-_type.dimension                        [4,4]
+_type.dimension                         '[4,4]'
 _type.container                         Matrix
 _type.purpose                           Number
 _type.source                            Assigned
@@ -2672,7 +2672,7 @@ _description.text
 ;
 _type.contents                          Real
 _type.container                         Matrix
-_type.dimension                        [4,4]
+_type.dimension                         '[4,4]'
 _type.purpose                           Number
 _type.source                            Assigned
 
@@ -2878,7 +2878,7 @@ _description.text
 ;
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         [3]
+_type.dimension                         '[3]'
 _type.purpose                           Number
 
 save_
@@ -3068,7 +3068,7 @@ _description.text
 ;
 _type.contents                          Text
 _type.container                         Matrix
-_type.dimension                         [4,4]
+_type.dimension                         '[4,4]'
 loop_
    _description_example.case
    _description_example.detail
@@ -3149,7 +3149,7 @@ _description.text
 ;
 _type.contents                          Text
 _type.container                         Matrix
-_type.dimension                         [4,4]
+_type.dimension                         '[4,4]'
 
 save_
 
@@ -3467,7 +3467,7 @@ _description.text
 ;
 _type.contents                          Text
 _type.container                         Matrix
-_type.dimension                         [4,4]
+_type.dimension                         '[4,4]'
 
 save_
 


### PR DESCRIPTION
These values need to be quoted to not be recognised as list data structures.