### PR TITLE
Remove several _definition.update attributes to resolve import issues.

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -452,7 +452,6 @@ _name.object_id                         label
 loop_
   _alias.definition_id                  '_atom_site_moment_label'
 _import.get [{"save":atom_site_id "file":templ_attr.cif}]
-_definition.update                      2016-05-24
 
 save_
 
@@ -862,7 +861,6 @@ _name.object_id                         label
 loop_
   _alias.definition_id                  '_atom_site_rotation_label'
 _import.get [{"save":atom_site_id "file":templ_attr.cif}]
-_definition.update                      2018-07-18
 
 save_
 


### PR DESCRIPTION
Both the importing definition and the imported save frame contains the _definition.update attribute. This is not allowed under the default import behaviour (exit on duplicate). Removing this attribute from the dictionary definitions is one way of solving this issue, but a different approach might also be suitable (e.g. replace on import, ignore on import).