### PR TITLE
Update definition of _atom_site_moment_Fourier.atom_site_label

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1083,9 +1083,9 @@ _description.text
      _atom_site.label from the ATOM_SITE loop, and otherwise conform
      to the rules for _atom_site_label.
 ;
-_type.contents                          Code
+_type.contents                          Word
 _type.container                         Single
-_type.purpose                           Encode
+_type.purpose                           Link
 _type.source                            Assigned
 _name.linked_item_id                    '_atom_site_moment.label'
 


### PR DESCRIPTION
The _atom_site_moment_Fourier.atom_site_label definition needs to be updated to conform to the requirements of the reference dictionary and the updated definition of the linked _atom_site.label data item.