### PR TITLE
Redefine examples as matrices instead of text fields

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3074,19 +3074,19 @@ _type.dimension                         '[4,4]'
 loop_
    _description_example.case
    _description_example.detail
-;   [[1 0 0 0.25]
-    [0 1 0 0   ]
-    [0 0 1 0   ]
-    [0 0 0 1   ]]
-;
+
+    [[1 0 0 0.25]
+     [0 1 0 0   ]
+     [0 0 1 0   ]
+     [0 0 0 1   ]]
 
 "Transformation from OG 5.6.24 C_P2' to BNS 4.12 P_C2_1"
 
-;   [[0  0 1 0   ]
+   [[0  0 1 0   ]
     [0 -1 0 0.25]
     [1  0 0 0   ]
     [0  0 0 1   ]]
-;
+
 "Transformation from OG 8.7.44 C_Pm' to BNS 7.31 P_Ac"
 
 save_


### PR DESCRIPTION
I overlooked this change in PR  #39.