### PR TITLE
Fix import issues

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -34,7 +34,7 @@ _description.text
    Head categories from other dictionaries are reparented to this category.
 ;
 _import.get  [{"file":"cif_core.dic" "save":"CIF_CORE" "mode":"Full"}
-              {"file":"cif_ms.dic"   "save":"CIF_MS"   "mode":"Full"}]
+              {"file":"cif_ms.dic"   "save":"MS_GROUP" "mode":"Full"}]
 save_
 
 

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -34,7 +34,7 @@ _description.text
    Head categories from other dictionaries are reparented to this category.
 ;
 _import.get  [{"file":"cif_core.dic" "save":"CIF_CORE" "mode":"Full"}
-              {"file":"cif_ms.dic"   "save":"MS_GROUP" "mode":"Full"}]
+              {"file":"cif_ms.dic"   "save":"MS_GROUP" "mode":"Full" "dupl":"Ignore"}]
 save_
 
 
@@ -57,6 +57,8 @@ _description.text
 ;
 _definition.scope                       Category
 _definition.class                       Loop
+    loop_
+    _category_key.name          '_atom_site_Fourier_wave_vector.seq_id'
 loop_
   _description_example.case
   _description_example.detail

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -33,8 +33,8 @@ _description.text
    This category is the parent of all categories in the dictionary.
    Head categories from other dictionaries are reparented to this category.
 ;
-_import.get  [{"file":"cif_core.dic" "save":"CIF_CORE" "mode":"Full"}
-              {"file":"cif_ms.dic"   "save":"MS_GROUP" "mode":"Full" "dupl":"Ignore"}]
+_import.get  [{"file":"cif_ms.dic"   "save":"MS_GROUP" "mode":"Full" "dupl":"Ignore"}]
+
 save_
 
 


### PR DESCRIPTION
This PR fixes the following issues:
* Corrects the name of the `Head` save frame from the `cif_ms.dic` dictionary. Previously, the data block name was incorrectly provided.
* Add the "Ignore" on duplicate flag to allow the import of save frames from the `cif_ms.dic` dictionary. This is probably the intended behaviour. Note, that under this mode, even if the definition of a duplicate category is ignored, non-duplicate items from that category are still imported.

Additional things to address:
* In order for the "Ignore" flag to function as intended, the `ATOM_SITE_FOURIER_WAVE_VECTOR` category key had to be explicitly specified in this dictionary as well (that part of the definition was copied from the `cif_ms.dic` dictionary. Maybe it would make sense to also copy the full definition of the `_atom_site_Fourier_wave_vector.seq_id` data item?
* The import of the `CIF_CORE` category is a bit redundant since it is already imported in full by the `CIF_MS` dictionary.
* In order for all import statements to function correctly, the import statements in the Modulated Structures dictionary should also be updated (https://github.com/COMCIFS/Modulated_Structures/pull/11).