### PR TITLE
Change the prefix of some save frames from 'save__' to 'save_'.

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -110,7 +110,7 @@ _atom_site_Fourier_wave_vector_q2_coeff
 save_
 
 
-save__atom_site_Fourier_wave_vector.q1_coeff
+save_atom_site_Fourier_wave_vector.q1_coeff
 _definition.id                         '_atom_site_Fourier_wave_vector.q1_coeff'
 _name.category_id                       atom_site_Fourier_wave_vector
 _name.object_id                         q1_coeff
@@ -143,7 +143,7 @@ loop_
 ;
 save_
 
-save__atom_site_Fourier_wave_vector.q2_coeff
+save_atom_site_Fourier_wave_vector.q2_coeff
 _definition.id                         '_atom_site_Fourier_wave_vector.q2_coeff'
 _name.category_id                       atom_site_Fourier_wave_vector
 _name.object_id                         q2_coeff
@@ -177,7 +177,7 @@ loop_
 
 save_
 
-save__atom_site_Fourier_wave_vector.q3_coeff
+save_atom_site_Fourier_wave_vector.q3_coeff
 _definition.id                         '_atom_site_Fourier_wave_vector.q3_coeff'
 _name.category_id                       atom_site_Fourier_wave_vector
 _name.object_id                         q3_coeff
@@ -203,7 +203,7 @@ _type.container                         Single
 save_
 
 
-save__atom_site_Fourier_wave_vector.q_coeff
+save_atom_site_Fourier_wave_vector.q_coeff
 
 _definition.id                          '_atom_site_Fourier_wave_vector.q_coeff'
 _name.category_id                       atom_site_Fourier_wave_vector


### PR DESCRIPTION
The `_atom_site_Fourier_wave_vector.q[123]_coeff` and `_atom_site_Fourier_wave_vector.q_coeff` data items are defined both in the this dictionary and in the imported `MS_DIC` **(although possibly with different semantics!)**. However, since the save frame names of these data items are different, both definitions are retained during the initial merge.

If you prefer, I can change all of the save frame names to not have the  double underscore or we can do it in a separate PR since those changes will be mainly cosmetic in whereas this one has some semantic implications. 