### PR TITLE
Update definition of _atom_site_moment_Fourier.wave_vector_seq_id

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1184,6 +1184,9 @@ _description.text
 ;
 _type.contents                          Text
 _type.container                         Single
+_type.purpose                           Link
+_type.source                            Assigned
+_name.linked_item_id                    '_atom_site_Fourier_wave_vector.seq_id'
 
 save_
 


### PR DESCRIPTION
This PR updates the `_atom_site_moment_Fourier.wave_vector_seq_id` data item definition to formally link to the `_atom_site_Fourier_wave_vector.seq_id` data item as described in the human-readable part of the definition.

Note, that it may be necessary to further update this data item since the `_atom_site_Fourier_wave_vector.seq_id` may change when resolving PR https://github.com/COMCIFS/Modulated_Structures/issues/14.

Note, that the assigned purpose and source values differ from the default ones, therefore this might conflict with PR https://github.com/COMCIFS/magnetic_dic/pull/46