### PR TITLE
Declare symops definitions to be recorded with the 'Encode' purpose.

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3677,6 +3677,7 @@ _description.text
 _type.contents                          Text
 _type.container                         Single
 _type.purpose                           Encode
+_type.source                            Recorded
 save_
 
 
@@ -3788,6 +3789,7 @@ _description.text
 _type.contents                          Text
 _type.container                         Single
 _type.purpose                           Encode
+_type.source                            Recorded
 loop_
   _description_example.case
   _description_example.detail
@@ -3900,6 +3902,7 @@ _description.text
 _type.contents                          Text
 _type.container                         Single
 _type.purpose                           Encode
+_type.source                            Recorded
 loop_
   _description_example.case
   _description_example.detail
@@ -3957,6 +3960,7 @@ _description.text
 _type.contents                          Text
 _type.container                         Single
 _type.purpose                           Encode
+_type.source                            Recorded
 loop_
   _description_example.case
   _description_example.detail
@@ -4053,7 +4057,9 @@ _description.text
 ;
 _type.contents                          Text
 _type.container                         Single
-_type.purpose                           Describe
+_type.purpose                           Encode
+_type.source                            Recorded
+
 loop_
   _description_example.case
   _description_example.detail


### PR DESCRIPTION
This PR updates symop definitions so they match those in the `CIF_CORE` dictionary.

Note, that the assigned source values differ from the default ones, therefore this might conflict with PR https://github.com/COMCIFS/magnetic_dic/pull/46.