### PR TITLE
Fix parent of imported category

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -2227,7 +2227,7 @@ save_ATOM_SITE_FOURIER_WAVE_VECTOR
     structural model. This category is fully defined in the modulated
     structures dictionary.
 ;
-    _name.category_id             MS_GROUP
+    _name.category_id             MAGNETIC
     _name.object_id               ATOM_SITE_FOURIER_WAVE_VECTOR
     _category_key.name            '_atom_site_Fourier_wave_vector.seq_id'
 

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -39,6 +39,198 @@ save_MAGNETIC
 
 save_
 
+save_ATOM_SITE_FOURIER_WAVE_VECTOR
+
+    _definition.id                ATOM_SITE_FOURIER_WAVE_VECTOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-05-24
+    _description.text
+;
+    Data items in the ATOM_SITE_FOURIER_WAVE_VECTOR category record
+    details about the wave vectors of the Fourier terms used in the
+    structural model. This category is fully defined in the modulated
+    structures dictionary.
+;
+    _name.category_id             MAGNETIC
+    _name.object_id               ATOM_SITE_FOURIER_WAVE_VECTOR
+    _category_key.name            '_atom_site_Fourier_wave_vector.seq_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+             _cell_wave_vector_seq_id
+             _cell_wave_vector_x
+             _cell_wave_vector_y
+             _cell_wave_vector_z
+                   1   0.30000   0.30000   0.00000
+                   2  -0.60000   0.30000   0.00000
+         loop_
+             _atom_site_Fourier_wave_vector_seq_id
+             _atom_site_Fourier_wave_vector_x
+             _atom_site_Fourier_wave_vector_y
+             _atom_site_Fourier_wave_vector_z
+             _atom_site_Fourier_wave_vector_q_coeff
+                 1   -0.30000   0.60000   0.00000  [1   1]
+                 2   -0.60000   0.30000   0.00000  [0   1]
+                 3   -0.30000  -0.30000   0.00000  [-1  0]
+;
+;
+         Example 1 - Hypothetical example showing the modulation wave vector
+         components expressed using the array data item
+         _atom_site_Fourier_wave_vector_q_coeff.
+;
+;
+         loop_
+         _cell_wave_vector_seq_id
+         _cell_wave_vector_x
+         _cell_wave_vector_y
+         _cell_wave_vector_z
+           1   0.30000   0.30000   0.00000
+           2  -0.60000   0.30000   0.00000
+         loop_
+         _atom_site_Fourier_wave_vector_seq_id
+         _atom_site_Fourier_wave_vector_x
+         _atom_site_Fourier_wave_vector_y
+         _atom_site_Fourier_wave_vector_z
+         _atom_site_Fourier_wave_vector_q1_coeff
+         _atom_site_Fourier_wave_vector_q2_coeff
+         1   -0.30000   0.60000   0.00000  1  1
+         2   -0.60000   0.30000   0.00000  0  1
+         3   -0.30000  -0.30000   0.00000 -1  0
+;
+;
+         Example 1 - As example 1, but using separate data items for each
+         individual component of the modulation wave vector.
+;
+
+save_
+
+save_atom_site_fourier_wave_vector.q1_coeff
+
+    _definition.id                '_atom_site_Fourier_wave_vector.q1_coeff'
+    _alias.definition_id          '_atom_site_Fourier_wave_vector_q1_coeff'
+    _definition.update            2016-06-21
+    _description.text
+;
+    For a given incommensurate modulation that contributes to the
+    structure, the wave vector of the modulation can be expressed as an
+    integer linear combination of the d independent wave vectors that
+    define the (3+d)-dimensional superspace.  The q1_coeff tag holds the
+    integer coefficient of the contribution of the first independent wave
+    vector, the q2_coeff tag holds the integer coefficient of the
+    contribution of the second independent wave vector, and so on.  At the
+    time of this writing, no examples with more than three independent
+    wave vectors are known, though there is no theoretical limit to the
+    number that could occur.  These tags are not explicitly magnetic; they
+    are equally applicable to any incommensurate modulation.
+;
+    _name.category_id             atom_site_Fourier_wave_vector
+    _name.object_id               q1_coeff
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with a as atom_site_Fourier_wave_vector
+    a.q1_coeff = a.q_coeff[0]
+;
+
+save_
+
+save_atom_site_fourier_wave_vector.q2_coeff
+
+    _definition.id                '_atom_site_Fourier_wave_vector.q2_coeff'
+    _alias.definition_id          '_atom_site_Fourier_wave_vector_q2_coeff'
+    _definition.update            2016-06-21
+    _description.text
+;
+    For a given incommensurate modulation that contributes to the
+    structure, the wave vector of the modulation can be expressed as an
+    integer linear combination of the d independent wave vectors that
+    define the (3+d)-dimensional superspace.  The q1_coeff tag holds the
+    integer coefficient of the contribution of the first independent wave
+    vector, the q2_coeff tag holds the integer coefficient of the
+    contribution of the second independent wave vector, and so on.  At the
+    time of this writing, no examples with more than three independent
+    wave vectors are known, though there is no theoretical limit to the
+    number that could occur.  These tags are not explicitly magnetic; they
+    are equally applicable to any incommensurate modulation.
+;
+    _name.category_id             atom_site_Fourier_wave_vector
+    _name.object_id               q2_coeff
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with a as atom_site_Fourier_wave_vector
+    a.q2_coeff = a.q_coeff[1]
+;
+
+save_
+
+save_atom_site_fourier_wave_vector.q3_coeff
+
+    _definition.id                '_atom_site_Fourier_wave_vector.q3_coeff'
+    _alias.definition_id          '_atom_site_Fourier_wave_vector_q3_coeff'
+    _definition.update            2016-06-21
+    _description.text
+;
+    For a given incommensurate modulation that contributes to the
+    structure, the wave vector of the modulation can be expressed as an
+    integer linear combination of the d independent wave vectors that
+    define the (3+d)-dimensional superspace.  The q1_coeff tag holds the
+    integer coefficient of the contribution of the first independent wave
+    vector, the q2_coeff tag holds the integer coefficient of the
+    contribution of the second independent wave vector, and so on.  At the
+    time of this writing, no examples with more than three independent
+    wave vectors are known, though there is no theoretical limit to the
+    number that could occur.  These tags are not explicitly magnetic; they
+    are equally applicable to any incommensurate modulation.
+;
+    _name.category_id             atom_site_Fourier_wave_vector
+    _name.object_id               q3_coeff
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+
+save_
+
+save_atom_site_fourier_wave_vector.q_coeff
+
+    _definition.id                '_atom_site_Fourier_wave_vector.q_coeff'
+    _alias.definition_id          '_atom_site_Fourier_wave_vector_q_coeff'
+    _definition.update            2016-06-21
+    _description.text
+;
+    For a given incommensurate modulation that contributes to the
+    structure, the wave vector of the modulation can be expressed as an
+    integer linear combination of the d independent wave vectors that
+    define the (3+d)-dimensional superspace.  This tag holds each of
+    the integer coefficients as an array. At the
+    time of this writing, no examples with more than three independent
+    wave vectors are known, though there is no theoretical limit to the
+    number that could occur.  These tags are not explicitly magnetic; they
+    are equally applicable to any incommensurate modulation.
+;
+    _name.category_id             atom_site_Fourier_wave_vector
+    _name.object_id               q_coeff
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Array
+    _type.dimension               '[]'
+    _type.contents                Integer
+
+save_
+
 save_ATOM_SITE_MOMENT
 
     _definition.id                ATOM_SITE_MOMENT
@@ -2211,198 +2403,6 @@ save_atom_type_scat.neutron_magnetic_source
 ;
     International Tables for Crystallography (2006). Vol. C, Section 4.4.5.
 ;
-
-save_
-
-save_ATOM_SITE_FOURIER_WAVE_VECTOR
-
-    _definition.id                ATOM_SITE_FOURIER_WAVE_VECTOR
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2016-05-24
-    _description.text
-;
-    Data items in the ATOM_SITE_FOURIER_WAVE_VECTOR category record
-    details about the wave vectors of the Fourier terms used in the
-    structural model. This category is fully defined in the modulated
-    structures dictionary.
-;
-    _name.category_id             MAGNETIC
-    _name.object_id               ATOM_SITE_FOURIER_WAVE_VECTOR
-    _category_key.name            '_atom_site_Fourier_wave_vector.seq_id'
-
-    loop_
-      _description_example.case
-      _description_example.detail
-;
-         loop_
-             _cell_wave_vector_seq_id
-             _cell_wave_vector_x
-             _cell_wave_vector_y
-             _cell_wave_vector_z
-                   1   0.30000   0.30000   0.00000
-                   2  -0.60000   0.30000   0.00000
-         loop_
-             _atom_site_Fourier_wave_vector_seq_id
-             _atom_site_Fourier_wave_vector_x
-             _atom_site_Fourier_wave_vector_y
-             _atom_site_Fourier_wave_vector_z
-             _atom_site_Fourier_wave_vector_q_coeff
-                 1   -0.30000   0.60000   0.00000  [1   1]
-                 2   -0.60000   0.30000   0.00000  [0   1]
-                 3   -0.30000  -0.30000   0.00000  [-1  0]
-;
-;
-         Example 1 - Hypothetical example showing the modulation wave vector
-         components expressed using the array data item
-         _atom_site_Fourier_wave_vector_q_coeff.
-;
-;
-         loop_
-         _cell_wave_vector_seq_id
-         _cell_wave_vector_x
-         _cell_wave_vector_y
-         _cell_wave_vector_z
-           1   0.30000   0.30000   0.00000
-           2  -0.60000   0.30000   0.00000
-         loop_
-         _atom_site_Fourier_wave_vector_seq_id
-         _atom_site_Fourier_wave_vector_x
-         _atom_site_Fourier_wave_vector_y
-         _atom_site_Fourier_wave_vector_z
-         _atom_site_Fourier_wave_vector_q1_coeff
-         _atom_site_Fourier_wave_vector_q2_coeff
-         1   -0.30000   0.60000   0.00000  1  1
-         2   -0.60000   0.30000   0.00000  0  1
-         3   -0.30000  -0.30000   0.00000 -1  0
-;
-;
-         Example 1 - As example 1, but using separate data items for each
-         individual component of the modulation wave vector.
-;
-
-save_
-
-save_atom_site_fourier_wave_vector.q1_coeff
-
-    _definition.id                '_atom_site_Fourier_wave_vector.q1_coeff'
-    _alias.definition_id          '_atom_site_Fourier_wave_vector_q1_coeff'
-    _definition.update            2016-06-21
-    _description.text
-;
-    For a given incommensurate modulation that contributes to the
-    structure, the wave vector of the modulation can be expressed as an
-    integer linear combination of the d independent wave vectors that
-    define the (3+d)-dimensional superspace.  The q1_coeff tag holds the
-    integer coefficient of the contribution of the first independent wave
-    vector, the q2_coeff tag holds the integer coefficient of the
-    contribution of the second independent wave vector, and so on.  At the
-    time of this writing, no examples with more than three independent
-    wave vectors are known, though there is no theoretical limit to the
-    number that could occur.  These tags are not explicitly magnetic; they
-    are equally applicable to any incommensurate modulation.
-;
-    _name.category_id             atom_site_Fourier_wave_vector
-    _name.object_id               q1_coeff
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _method.purpose               Evaluation
-    _method.expression
-;
-    with a as atom_site_Fourier_wave_vector
-    a.q1_coeff = a.q_coeff[0]
-;
-
-save_
-
-save_atom_site_fourier_wave_vector.q2_coeff
-
-    _definition.id                '_atom_site_Fourier_wave_vector.q2_coeff'
-    _alias.definition_id          '_atom_site_Fourier_wave_vector_q2_coeff'
-    _definition.update            2016-06-21
-    _description.text
-;
-    For a given incommensurate modulation that contributes to the
-    structure, the wave vector of the modulation can be expressed as an
-    integer linear combination of the d independent wave vectors that
-    define the (3+d)-dimensional superspace.  The q1_coeff tag holds the
-    integer coefficient of the contribution of the first independent wave
-    vector, the q2_coeff tag holds the integer coefficient of the
-    contribution of the second independent wave vector, and so on.  At the
-    time of this writing, no examples with more than three independent
-    wave vectors are known, though there is no theoretical limit to the
-    number that could occur.  These tags are not explicitly magnetic; they
-    are equally applicable to any incommensurate modulation.
-;
-    _name.category_id             atom_site_Fourier_wave_vector
-    _name.object_id               q2_coeff
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _method.purpose               Evaluation
-    _method.expression
-;
-    with a as atom_site_Fourier_wave_vector
-    a.q2_coeff = a.q_coeff[1]
-;
-
-save_
-
-save_atom_site_fourier_wave_vector.q3_coeff
-
-    _definition.id                '_atom_site_Fourier_wave_vector.q3_coeff'
-    _alias.definition_id          '_atom_site_Fourier_wave_vector_q3_coeff'
-    _definition.update            2016-06-21
-    _description.text
-;
-    For a given incommensurate modulation that contributes to the
-    structure, the wave vector of the modulation can be expressed as an
-    integer linear combination of the d independent wave vectors that
-    define the (3+d)-dimensional superspace.  The q1_coeff tag holds the
-    integer coefficient of the contribution of the first independent wave
-    vector, the q2_coeff tag holds the integer coefficient of the
-    contribution of the second independent wave vector, and so on.  At the
-    time of this writing, no examples with more than three independent
-    wave vectors are known, though there is no theoretical limit to the
-    number that could occur.  These tags are not explicitly magnetic; they
-    are equally applicable to any incommensurate modulation.
-;
-    _name.category_id             atom_site_Fourier_wave_vector
-    _name.object_id               q3_coeff
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-
-save_
-
-save_atom_site_fourier_wave_vector.q_coeff
-
-    _definition.id                '_atom_site_Fourier_wave_vector.q_coeff'
-    _alias.definition_id          '_atom_site_Fourier_wave_vector_q_coeff'
-    _definition.update            2016-06-21
-    _description.text
-;
-    For a given incommensurate modulation that contributes to the
-    structure, the wave vector of the modulation can be expressed as an
-    integer linear combination of the d independent wave vectors that
-    define the (3+d)-dimensional superspace.  This tag holds each of
-    the integer coefficients as an array. At the
-    time of this writing, no examples with more than three independent
-    wave vectors are known, though there is no theoretical limit to the
-    number that could occur.  These tags are not explicitly magnetic; they
-    are equally applicable to any incommensurate modulation.
-;
-    _name.category_id             atom_site_Fourier_wave_vector
-    _name.object_id               q_coeff
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Array
-    _type.dimension               '[]'
-    _type.contents                Integer
 
 save_
 


### PR DESCRIPTION
This PR changes the parent category of the `ATOM_SITE_FOURIER_WAVE_VECTOR` category from `MS_GROUP` to `MAGNETIC`. After the change in the parent category, the `ATOM_SITE_FOURIER_WAVE_VECTOR` had to be moved to adhere to the dictionary style guide child category ordering rules.

The `ATOM_SITE_FOURIER_WAVE_VECTOR`  category is originally defined in the `CIF_MS` dictionary and expanded/overwritten in this dictionary. However, since the `CIF_MS` dictionary is imported in full (head-in-head import), all top level categories from the `CIF_MS` dictionary become automatically reparented from `MS_GROUP` to `MAGNETIC`. Furthermore, the `MS_GROUP` head category is not imported at all, thus resulting in a missing parent category.