### PR TITLE
Fix `*_transform_pp_abc` items

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -2525,7 +2525,7 @@ save_parent_space_group.child_transform_pp_abc
 ;
     _name.category_id             parent_space_group
     _name.object_id               child_transform_Pp_abc
-    _type.purpose                 Describe
+    _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
@@ -2602,7 +2602,7 @@ save_parent_space_group.transform_pp_abc
 ;
     _name.category_id             parent_space_group
     _name.object_id               transform_Pp_abc
-    _type.purpose                 Describe
+    _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
@@ -3309,7 +3309,7 @@ save_
 save_space_group_magn.transform_bns_pp_abc
 
     _definition.id                '_space_group_magn.transform_BNS_Pp_abc'
-    _definition.update            2023-01-17
+    _definition.update            2024-01-19
     _description.text
 ;
     This item specifies the transformation (P,p) of the basis
@@ -3331,7 +3331,7 @@ save_space_group_magn.transform_bns_pp_abc
 ;
     _name.category_id             space_group_magn
     _name.object_id               transform_BNS_Pp_abc
-    _type.purpose                 Describe
+    _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
@@ -3375,7 +3375,7 @@ save_
 save_space_group_magn.transform_og_pp_abc
 
     _definition.id                '_space_group_magn.transform_OG_Pp_abc'
-    _definition.update            2023-01-17
+    _definition.update            2024-01-19
     _description.text
 ;
     This item specifies the transformation (P,p) of the basis
@@ -3397,7 +3397,7 @@ save_space_group_magn.transform_og_pp_abc
 ;
     _name.category_id             space_group_magn
     _name.object_id               transform_OG_Pp_abc
-    _type.purpose                 Describe
+    _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
@@ -3479,7 +3479,7 @@ save_space_group_magn_ssg_transforms.pp_superspace
 
     _definition.id
         '_space_group_magn_ssg_transforms.Pp_superspace'
-    _definition.update            2016-06-09
+    _definition.update            2024-01-19
     _description.text
 ;
     This item specifies the transformation (P,p) of the superspace
@@ -3704,7 +3704,7 @@ save_space_group_magn_transforms.pp_abc
 ;
     _name.category_id             space_group_magn_transforms
     _name.object_id               Pp_abc
-    _type.purpose                 Describe
+    _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
@@ -4357,5 +4357,6 @@ save_
        Changed the object id of the _parent_space_group.name_H-M_alt data item.
 
        Corrected definitions of _parent_space_group.child_transform_pp_abc and
-       _parent_space_group.transform_pp_abc.
+       _parent_space_group.transform_pp_abc. Change the purpose of all *_pp_abc
+       items to 'Encode'.
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -10,7 +10,7 @@ data_MAGNETIC_CIF
     _dictionary.title             MAGNETIC_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.9
-    _dictionary.date              2023-07-17
+    _dictionary.date              2024-01-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/magnetic_dic/main/cif_mag.dic
     _dictionary.ddl_conformance   3.11.09
@@ -2505,7 +2505,7 @@ save_
 save_parent_space_group.child_transform_pp_abc
 
     _definition.id                '_parent_space_group.child_transform_Pp_abc'
-    _definition.update            2023-01-17
+    _definition.update            2024-01-19
     _description.text
 ;
     This item specifies the transformation (P,p) of the basis vectors
@@ -2525,11 +2525,10 @@ save_parent_space_group.child_transform_pp_abc
 ;
     _name.category_id             parent_space_group
     _name.object_id               child_transform_Pp_abc
-    _type.purpose                 Number
+    _type.purpose                 Describe
     _type.source                  Assigned
-    _type.container               Matrix
-    _type.dimension               '[4,4]'
-    _type.contents                Real
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -2593,7 +2592,7 @@ save_
 save_parent_space_group.transform_pp_abc
 
     _definition.id                '_parent_space_group.transform_Pp_abc'
-    _definition.update            2016-06-09
+    _definition.update            2024-01-19
     _description.text
 ;
     Analogous tags: Notation and usage is analogous to
@@ -2603,11 +2602,10 @@ save_parent_space_group.transform_pp_abc
 ;
     _name.category_id             parent_space_group
     _name.object_id               transform_Pp_abc
-    _type.purpose                 Number
+    _type.purpose                 Describe
     _type.source                  Assigned
-    _type.container               Matrix
-    _type.dimension               '[4,4]'
-    _type.contents                Real
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -4351,10 +4349,13 @@ save_
        _atom_site_moment .cartesion* items, corrected and improved *_symmform
        descriptions. Created the atom_site_rotation category. (B Campbell)
 ;
-         0.9.9                    2023-07-17
+         0.9.9                    2024-01-19
 ;
        Changed several instances of "Jones-Faithful notation" to
        "Jones faithful notation".
 
        Changed the object id of the _parent_space_group.name_H-M_alt data item.
+
+       Corrected definitions of _parent_space_group.child_transform_pp_abc and
+       _parent_space_group.transform_pp_abc.
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -4357,6 +4357,6 @@ save_
        Changed the object id of the _parent_space_group.name_H-M_alt data item.
 
        Corrected definitions of _parent_space_group.child_transform_pp_abc and
-       _parent_space_group.transform_pp_abc. Change the purpose of all *_pp_abc
+       _parent_space_group.transform_pp_abc. Changed the purpose of all *_pp_abc
        items to 'Encode'.
 ;


### PR DESCRIPTION
This PR mainly addresses inconsistencies in the definitions of the `_parent_space_group.child_transform_pp_abc` and `_parent_space_group.transform_pp_abc`  data items. Specifically, the attributes assigned to these items did not seem compatible with their human-readable definitions. I tried to fix it using similar data items (e.g. `_space_group_magn.transform_BNS_Pp_abc`) as a template.

Also, looking at other similar `*_pp_abc` items I noticed that they are often also accompanied by the `*_pp` item which records the transformation matrix. Maybe that was also the original intention with these items and the corresponding `_parent_space_group.child_transform_pp` and `_parent_space_group.transform_pp` items should be added?

Finally, I also changed the purpose of several other `*_pp_abc` items from `Describe` to `Encode` since I assume that they are intended to be machine-readable (similarly to the `_space_group_symop.operation_xyz` data item from `CIF_CORE`). Note, that `_space_group_magn_transforms.pp_abc` was already assigned the `Encode` purpose. 