### PR TITLE
Restrict the values of _atom_site_moment_Fourier.wave_vector_seq_id

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -10,7 +10,7 @@ data_MAGNETIC_CIF
     _dictionary.title             MAGNETIC_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.9
-    _dictionary.date              2024-01-19
+    _dictionary.date              2024-02-06
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/magnetic_dic/main/cif_mag.dic
     _dictionary.ddl_conformance   3.11.09
@@ -1137,7 +1137,7 @@ save_
 save_atom_site_moment_fourier.wave_vector_seq_id
 
     _definition.id                '_atom_site_moment_Fourier.wave_vector_seq_id'
-    _definition.update            2016-05-24
+    _definition.update            2024-02-06
     _description.text
 ;
     An arbitrary code that uniquely identifies the wave vector for
@@ -1158,7 +1158,8 @@ save_atom_site_moment_fourier.wave_vector_seq_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Integer
+    _enumeration.range            0:
 
 save_
 
@@ -4383,7 +4384,7 @@ save_
        _atom_site_moment .cartesion* items, corrected and improved *_symmform
        descriptions. Created the atom_site_rotation category. (B Campbell)
 ;
-         0.9.9                    2024-01-19
+         0.9.9                    2024-02-06
 ;
        Changed several instances of "Jones-Faithful notation" to
        "Jones faithful notation".
@@ -4398,4 +4399,7 @@ save_
        _space_group_magn.point_group_number in favour of the newly added
        _space_group_magn.point_group_name_H-M and
        _space_group_magn.point_group_number_Litvin.
+
+       Restricted the values of _atom_site_moment_Fourier.wave_vector_seq_id
+       to non-negative integers.
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1146,9 +1146,9 @@ save_atom_site_moment_fourier.wave_vector_seq_id
     _definition.update            2024-02-07
     _description.text
 ;
-    An arbitrary non-negative integer code that uniquely identifies the wave
-    vector for which magnetic Fourier modulation components are to be described
-    within the ATOM_SITE_MOMENT_FOURIER loop. It must match one of
+    An arbitrary positive integer code that uniquely identifies the wave vector
+    for which magnetic Fourier modulation components are to be described within
+    the ATOM_SITE_MOMENT_FOURIER loop. It must match one of
     the _atom_site_Fourier_wave_vector.seq_id values in the
     ATOM_SITE_FOURIER_WAVE_VECTOR loop.
 
@@ -1165,7 +1165,7 @@ save_atom_site_moment_fourier.wave_vector_seq_id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
 
 save_
 
@@ -4412,5 +4412,5 @@ save_
        Added evaluation method for _atom_site_Fourier_wave_vector.q3_coeff.
 
        Restricted the values of _atom_site_moment_Fourier.wave_vector_seq_id
-       to non-negative integers.
+       to positive integers.
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1140,9 +1140,9 @@ save_atom_site_moment_fourier.wave_vector_seq_id
     _definition.update            2024-02-06
     _description.text
 ;
-    An arbitrary code that uniquely identifies the wave vector for
-    which magnetic Fourier modulation components are to be described
-    within the ATOM_SITE_MOMENT_FOURIER loop.  It must match one of
+    An arbitrary non-negative integer code that uniquely identifies the wave
+    vector for which magnetic Fourier modulation components are to be described
+    within the ATOM_SITE_MOMENT_FOURIER loop. It must match one of
     the _atom_site_Fourier_wave_vector.seq_id values in the
     ATOM_SITE_FOURIER_WAVE_VECTOR loop.
 


### PR DESCRIPTION
This PR redefines the `_atom_site_moment_Fourier.wave_vector_seq_id` from `Text` to a non-negative `Integer` since such values are expected by various symmform data items (see definition of `_atom_site_moment_Fourier_param.cos_symmform` and the following comment https://github.com/COMCIFS/magnetic_dic/issues/67#issuecomment-1928842478).

The non-negative enumeration range of 0: was taken from the definition of the linked `_atom_site_Fourier_wave_vector.seq_id` data item from the Modulation dictionary. However, I am not completely sure if the authors intended to include 0 into the set of allowed integers or simply though that the enumeration range is exclusive. Please let me know if this should be redefined to exclude the 0.