### PR TITLE
Declare the dictionary as conformant to DDLm version 4.1.0.

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -10,10 +10,10 @@ data_MAGNETIC_CIF
     _dictionary.title             MAGNETIC_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.9
-    _dictionary.date              2024-01-19
+    _dictionary.date              2024-02-07
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/magnetic_dic/main/cif_mag.dic
-    _dictionary.ddl_conformance   3.11.09
+    _dictionary.ddl_conformance   4.1.0
     _dictionary.namespace         CifCore
     _description.text
 ;
@@ -4383,7 +4383,7 @@ save_
        _atom_site_moment .cartesion* items, corrected and improved *_symmform
        descriptions. Created the atom_site_rotation category. (B Campbell)
 ;
-         0.9.9                    2024-01-19
+         0.9.9                    2024-02-07
 ;
        Changed several instances of "Jones-Faithful notation" to
        "Jones faithful notation".
@@ -4398,4 +4398,7 @@ save_
        _space_group_magn.point_group_number in favour of the newly added
        _space_group_magn.point_group_name_H-M and
        _space_group_magn.point_group_number_Litvin.
+
+       Declared the dictionary as conformant to the DDLm reference dictionary
+       version 4.1.0.
 ;


### PR DESCRIPTION
This PR deals with the technical side of CIF/DDLm.

The currently declared DDLm version 3.11.09 is quite outdated while version 4.1.0 is the latest tagged version (see https://github.com/COMCIFS/cif_core/blob/3.2.0/ddl.dic, tag 3.2.0 of the CIF_CORE repository). For all practical purposes we are already using DDLm 4.1.0 (or even later) so simply updating it does not seem to break anything.