### PR TITLE
Add a more standard reference to _atom_sites_rot_Fourier.axes_description

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1963,10 +1963,8 @@ save_atom_sites_moment_fourier.axes_description
     _atom_site_moment_Fourier.axis.
 
     Analogous tags:
-    msCIF:_atom_sites_displace_Fourier.axes_description.
-
-    It is not difficult to imagine an
-    _atom_sites_rot_Fourier.axes_description tag.
+    msCIF:_atom_sites_displace_Fourier.axes_description,
+    msCIF:_atom_sites_rot_Fourier.axes_description.
 ;
     _name.category_id             atom_sites_moment_Fourier
     _name.object_id               axes_description


### PR DESCRIPTION
This PR contains one minor cosmetic change.

The earlier phrasing was probably added before the introduction of the `_atom_sites_rot_Fourier.axes_description` data item in the modulation dictionary, but since it is now properly defined there, a fully qualified reference seems more reasonable.

I did not modify the change dates nor added a new changelog message since this minor change can probably be viewed as part of the cosmetic changes which were just recently made by @nautolycus.