### PR TITLE
Add structure keys to ATOM_SITE_*

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1370,7 +1370,8 @@ save_atom_site_moment_fourier.atom_site_label
     _definition.update            2016-05-24
     _description.text
 ;
-    This string uniquely identifies the atom for which the Fourier
+    This string, in conjunction with _atom_site_moment_fourier.structure_id,
+    uniquely identifies the atom for which the Fourier
     modulation  components are to be specified.  The Fourier
     modulation components are always presented in a separate loop
     (not in the ATOM_SITE loop).  This string must match an
@@ -1449,6 +1450,24 @@ save_atom_site_moment_fourier.id
       _description_example.case
          K2_1_z
          Se1_2_x
+
+save_
+
+save_atom_site_moment_fourier.structure_id
+
+    _definition.id                '_atom_site_moment_fourier.structure_id'
+    _definition.update            2026-06-03
+    _description.text
+;
+    A code identifying the structure to which this atom site rotation belongs.
+;
+    _name.category_id             atom_site_moment_fourier
+    _name.object_id               structure_id
+    _name.linked_item_id          '_atom_site_moment.structure_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -2043,7 +2062,7 @@ save_ATOM_SITE_MOMENT_SPECIAL_FUNC
     _definition.id                ATOM_SITE_MOMENT_SPECIAL_FUNC
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-05-17
+    _definition.update            2026-06-03
     _description.text
 ;
     Data items in the ATOM_SITE_MOMENT_SPECIAL_FUNC category record
@@ -2071,8 +2090,11 @@ save_ATOM_SITE_MOMENT_SPECIAL_FUNC
 ;
     _name.category_id             CIF_MAG_HEAD
     _name.object_id               ATOM_SITE_MOMENT_SPECIAL_FUNC
-    _category_key.name
-        '_atom_site_moment_special_func.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_moment_special_func.atom_site_label'
+         '_atom_site_moment_special_func.structure_id'
 
 save_
 
@@ -2405,6 +2427,25 @@ save_atom_site_moment_special_func.sawtooth_w_su
     _units.code                   Bohr_magnetons
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site_moment_special_func.structure_id
+
+    _definition.id                '_atom_site_moment_special_func.structure_id'
+    _definition.update            2026-06-03
+    _description.text
+;
+    A code identifying the structure to which this atom site moment
+    special function belongs.
+;
+    _name.category_id             atom_site_moment_special_func
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -5088,5 +5129,8 @@ save_
 
        Improved clarity in transform_Pp_abc definitions.
 
-       Added _structure.id key to ATOM_SITE_MOMENT, ATOM_SITE_ROTATION
+       Added _structure.id key to ATOM_SITE_MOMENT, ATOM_SITE_ROTATION, and
+       ATOM_SITE_MOMENT_SPECIAL_FUNC.
+
+       Added _structure.id as linked data name in ATOM_SITE_MOMENT_FOURIER.
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1527,6 +1527,12 @@ save_ATOM_SITE_MOMENT_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_MOMENT_FOURIER
     _name.object_id               ATOM_SITE_MOMENT_FOURIER_PARAM
+
+    loop_
+      _category_key.name
+         '_atom_site_moment_Fourier_param.id'
+         '_atom_site_moment_Fourier_param.structure_id'
+
     _description_example.case
 ;
     loop_
@@ -2061,6 +2067,25 @@ save_atom_site_moment_fourier_param.sin_symmform
 save_
 
 save_atom_site_moment_fourier_param.structure_id
+
+    _definition.id
+        '_atom_site_moment_Fourier_param.structure_id'
+    _definition.update            2026-06-03
+    _description.text
+;
+    A code identifying the structure to which this atom site moment
+    Fourier parameter belongs.
+;
+    _name.category_id             atom_site_moment_Fourier_param
+    _name.object_id               structure_id
+    _name.linked_item_id          '_atom_site_moment.structure_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_ATOM_SITE_MOMENT_SPECIAL_FUNC
 
     _definition.id                ATOM_SITE_MOMENT_SPECIAL_FUNC

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1348,7 +1348,7 @@ save_ATOM_SITE_MOMENT_FOURIER
     _definition.id                ATOM_SITE_MOMENT_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-05-17
+    _definition.update            2026-06-03
     _description.text
 ;
     Data items in the ATOM_SITE_MOMENT_FOURIER category record
@@ -1360,7 +1360,11 @@ save_ATOM_SITE_MOMENT_FOURIER
 ;
     _name.category_id             CIF_MAG_HEAD
     _name.object_id               ATOM_SITE_MOMENT_FOURIER
-    _category_key.name            '_atom_site_moment_Fourier.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_moment_Fourier.id'
+         '_atom_site_moment_Fourier.structure_id'
 
 save_
 
@@ -1459,7 +1463,7 @@ save_atom_site_moment_fourier.structure_id
     _definition.update            2026-06-03
     _description.text
 ;
-    A code identifying the structure to which this atom site rotation belongs.
+    A code identifying the structure to which this atom site moment belongs.
 ;
     _name.category_id             atom_site_moment_Fourier
     _name.object_id               structure_id
@@ -5282,6 +5286,9 @@ save_
 ;
          0.9.9                    2026-06-10
 ;
+       Added _structure.id key to ATOM_SITE_MOMENT, ATOM_SITE_ROTATION,
+       ATOM_SITE_MOMENT_FOURIER, ATOM_SITE_MOMENT_SPECIAL_FUNC.
+
        Added key to SPACE_GROUP_MAGN, and linked key data names to:
        SPACE_GROUP_MAGN_SSG_TRANSFORMS
        SPACE_GROUP_MAGN_TRANSFORMS
@@ -5347,8 +5354,4 @@ save_
 
        Improved clarity in transform_Pp_abc definitions.
 
-       Added _structure.id key to ATOM_SITE_MOMENT, ATOM_SITE_ROTATION, and
-       ATOM_SITE_MOMENT_SPECIAL_FUNC.
-
-       Added _structure.id as linked data name in ATOM_SITE_MOMENT_FOURIER.
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1455,13 +1455,13 @@ save_
 
 save_atom_site_moment_fourier.structure_id
 
-    _definition.id                '_atom_site_moment_fourier.structure_id'
+    _definition.id                '_atom_site_moment_Fourier.structure_id'
     _definition.update            2026-06-03
     _description.text
 ;
     A code identifying the structure to which this atom site rotation belongs.
 ;
-    _name.category_id             atom_site_moment_fourier
+    _name.category_id             atom_site_moment_Fourier
     _name.object_id               structure_id
     _name.linked_item_id          '_atom_site_moment.structure_id'
     _type.purpose                 Link

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -636,7 +636,7 @@ save_atom_site_moment.structure_id
     _definition.update            2026-06-03
     _description.text
 ;
-    A code identifying the structure to which this atom site belongs.
+    A code identifying the structure to which this atom site moment belongs.
 ;
     _name.category_id             atom_site_moment
     _name.object_id               structure_id
@@ -691,7 +691,7 @@ save_ATOM_SITE_ROTATION
     _definition.id                ATOM_SITE_ROTATION
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2018-07-18
+    _definition.update            2026-06-03
     _description.text
 ;
     This category provides a loop for presenting atom-site axial-vector
@@ -710,7 +710,11 @@ save_ATOM_SITE_ROTATION
 ;
     _name.category_id             ATOM_SITE
     _name.object_id               ATOM_SITE_ROTATION
-    _category_key.name            '_atom_site_rotation.label'
+
+    loop_
+      _category_key.name
+         '_atom_site_rotation.label'
+         '_atom_site_rotation.structure_id'
 
 save_
 
@@ -1280,6 +1284,24 @@ save_atom_site_rotation.spherical_polar_su
     _units.code                   degrees
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site_rotation.structure_id
+
+    _definition.id                '_atom_site_rotation.structure_id'
+    _definition.update            2026-06-03
+    _description.text
+;
+    A code identifying the structure to which this atom site rotation belongs.
+;
+    _name.category_id             atom_site_rotation
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -5066,5 +5088,5 @@ save_
 
        Improved clarity in transform_Pp_abc definitions.
 
-       Added _structure.id key to ATOM_SITE_MOMENT
+       Added _structure.id key to ATOM_SITE_MOMENT, ATOM_SITE_ROTATION
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -2068,8 +2068,7 @@ save_
 
 save_atom_site_moment_fourier_param.structure_id
 
-    _definition.id
-        '_atom_site_moment_Fourier_param.structure_id'
+    _definition.id                '_atom_site_moment_Fourier_param.structure_id'
     _definition.update            2026-06-03
     _description.text
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -11,7 +11,7 @@ data_CIF_MAG
     _dictionary.title             CIF_MAG
     _dictionary.class             Instance
     _dictionary.version           0.9.9
-    _dictionary.date              2026-05-28
+    _dictionary.date              2026-06-03
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/magnetic_dic/main/cif_mag.dic
     _dictionary.ddl_conformance   4.1.0
@@ -47,7 +47,7 @@ save_ATOM_SITE_MOMENT
     _definition.id                ATOM_SITE_MOMENT
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2016-05-24
+    _definition.update            2026-06-03
     _description.text
 ;
     This category provides a loop for presenting the magnetic moments
@@ -58,7 +58,11 @@ save_ATOM_SITE_MOMENT
 ;
     _name.category_id             ATOM_SITE
     _name.object_id               ATOM_SITE_MOMENT
-    _category_key.name            '_atom_site_moment.label'
+
+    loop_
+      _category_key.name
+         '_atom_site_moment.label'
+         '_atom_site_moment.structure_id'
 
 save_
 
@@ -623,6 +627,24 @@ save_atom_site_moment.spherical_polar_su
     _units.code                   degrees
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site_moment.structure_id
+
+    _definition.id                '_atom_site_moment.structure_id'
+    _definition.update            2026-06-03
+    _description.text
+;
+    A code identifying the structure to which this atom site belongs.
+;
+    _name.category_id             atom_site_moment
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -4989,7 +5011,7 @@ save_
        _atom_site_moment.Cartn* items, corrected and improved *_symmform
        descriptions. Created the atom_site_rotation category. (B Campbell)
 ;
-         0.9.9                    2026-05-28
+         0.9.9                    2026-06-03
 ;
        Changed several instances of "Jones-Faithful notation" to
        "Jones faithful notation".
@@ -5043,4 +5065,6 @@ save_
        because it is defined in cif_ms.dic.
 
        Improved clarity in transform_Pp_abc definitions.
+
+       Added _structure.id key to ATOM_SITE_MOMENT
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -1527,7 +1527,6 @@ save_ATOM_SITE_MOMENT_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_MOMENT_FOURIER
     _name.object_id               ATOM_SITE_MOMENT_FOURIER_PARAM
-    _category_key.name            '_atom_site_moment_Fourier_param.id'
     _description_example.case
 ;
     loop_
@@ -2061,6 +2060,7 @@ save_atom_site_moment_fourier_param.sin_symmform
 
 save_
 
+save_atom_site_moment_fourier_param.structure_id
 save_ATOM_SITE_MOMENT_SPECIAL_FUNC
 
     _definition.id                ATOM_SITE_MOMENT_SPECIAL_FUNC

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -640,7 +640,7 @@ save_atom_site_moment.structure_id
 ;
     _name.category_id             atom_site_moment
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
+    _name.linked_item_id          '_atom_site.structure_id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
@@ -1297,7 +1297,7 @@ save_atom_site_rotation.structure_id
 ;
     _name.category_id             atom_site_rotation
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
+    _name.linked_item_id          '_atom_site.structure_id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -2077,7 +2077,7 @@ save_atom_site_moment_fourier_param.structure_id
 ;
     _name.category_id             atom_site_moment_Fourier_param
     _name.object_id               structure_id
-    _name.linked_item_id          '_atom_site_moment.structure_id'
+    _name.linked_item_id          '_atom_site_moment_Fourier.structure_id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single


### PR DESCRIPTION
see #93 
EDITED: all now linked keys

Added keys to fully specify `_atom_site.label`, after the addition of _structure.id to `ATOM_SITE` key in `multi_block`.

```
Added _structure.id key to 
ATOM_SITE_MOMENT 
ATOM_SITE_ROTATION
ATOM_SITE_MOMENT_SPECIAL_FUNC.
ATOM_SITE_MOMENT_FOURIER.
```

~~`_atom_site_moment_fourier.structure_id` will need to be explicitly given a value. The remainder will auto-populate if `_structure.id` is given in the same data block.~~


