### PR TITLE
properly quote examples in `_description_example.case`

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3431,15 +3431,15 @@ save_space_group_magn.name_og
 
     loop_
       _description_example.case
-         P1
-         P11'
-         P_S1
-         P-1
-         P-11'
-         P-1'
-         P_2s-1
-         C_P2
-         Ia'-3'd'
+         "P1"
+         "P11'"
+         "P_S1"
+         "P-1"
+         "P-11'"
+         "P-1'"
+         "P_2s-1"
+         "C_P2"
+         "Ia'-3'd'"
 
 save_
 

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3716,14 +3716,14 @@ save_space_group_magn.point_group_name_uni
 
     loop_
       _description_example.case
-         1.1
-         1.1'
-         -1.1
-         -1.1'
-         -1'
-         4mm.1
-         4'm'm
-         4'mm'
+         "1.1"
+         "1.1'"
+         "-1.1"
+         "-1.1'"
+         "-1'"
+         "4mm.1"
+         "4'm'm"
+         "4'mm'"
 
 save_
 

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3804,29 +3804,29 @@ save_space_group_magn.ssg_name
     loop_
       _description_example.case
       _description_example.detail
-         Pmmm(0,0,g)ss0
+         "Pmmm(0,0,g)ss0"
 ;
          type-1 MBSG Pmmm
 ;
-         Pmmm.1'(0,0,g)ss00
+         "Pmmm.1'(0,0,g)ss00"
 ;
          type-2 MBSG Pmmm.1', with no basic-cell or
           modulated moments allowed
 ;
-         Pmmm.1'(0,0,g)ss0s
+         "Pmmm.1'(0,0,g)ss0s"
 ;
          type-2 MBSG Pmmm.1', with magnetic modulations
           allowed, but not basic-cell moments
 ;
-         Pm'm'm(0,0,g)ss0
+         "Pm'm'm(0,0,g)ss0"
 ;
          type-3 MBSG Pm'm'm
 ;
-         Pmmm.1'_a(0,0,g)ss00
+         "Pmmm.1'_a(0,0,g)ss00"
 ;
          type-4 MBSG P_ammm with purely external anti-centering
 ;
-         Pmmm.1'_a(0,0,g)ss0s
+         "Pmmm.1'_a(0,0,g)ss0s"
 ;
          type-4 MBSG P_ammm with superspace anti-centering
 ;

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3379,15 +3379,15 @@ save_space_group_magn.name_bns
 
     loop_
       _description_example.case
-         P1
-         P11'
-         P_S1
-         P-1
-         P-11'
-         P-1'
-         P_S-1
-         P_C2
-         Ia'-3d'
+         "P1"
+         "P11'"
+         "P_S1"
+         "P-1"
+         "P-11'"
+         "P-1'"
+         "P_S-1"
+         "P_C2"
+         "Ia'-3d'"
 
 save_
 

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -3886,13 +3886,13 @@ save_space_group_magn.ssg_number
     loop_
       _description_example.case
       _description_example.detail
-         47.1.9.3.m249.1   "Pmmm.1(0,0,g)ss0     SSG = 47.1.9.3, BMSG = 47.249"
-         47.1.9.3.m250.1'  "Pmmm.1'(0,0,g)ss00   SSG = 47.1.9.3, BMSG = 47.250"
-         47.1.9.3.m250.2   "Pmmm.1'(0,0,g)ss0s   SSG = 47.1.9.3, BMSG = 47.250"
-         47.1.9.3.m252.1   "Pm'm'm(0,0,g)ss0     SSG = 47.1.9.3, BMSG = 47.252"
-         47.1.9.3.m254.1   "Pmmm.1'_a(0,0,g)ss00 SSG = 47.1.9.3, BMSG = 47.254"
-         47.1.9.3.m254.2   "Pmmm.1'_c(0,0,g)ss00 SSG = 47.1.9.3, BMSG = 47.254"
-         47.1.9.3.m254.3   "Pmmm.1'_a(0,0,g)ss0s SSG = 47.1.9.3, BMSG = 47.254"
+         "47.1.9.3.m249.1"   "Pmmm.1(0,0,g)ss0     SSG = 47.1.9.3, BMSG = 47.249"
+         "47.1.9.3.m250.1'"  "Pmmm.1'(0,0,g)ss00   SSG = 47.1.9.3, BMSG = 47.250"
+         "47.1.9.3.m250.2"   "Pmmm.1'(0,0,g)ss0s   SSG = 47.1.9.3, BMSG = 47.250"
+         "47.1.9.3.m252.1"   "Pm'm'm(0,0,g)ss0     SSG = 47.1.9.3, BMSG = 47.252"
+         "47.1.9.3.m254.1"   "Pmmm.1'_a(0,0,g)ss00 SSG = 47.1.9.3, BMSG = 47.254"
+         "47.1.9.3.m254.2"   "Pmmm.1'_c(0,0,g)ss00 SSG = 47.1.9.3, BMSG = 47.254"
+         "47.1.9.3.m254.3"   "Pmmm.1'_a(0,0,g)ss0s SSG = 47.1.9.3, BMSG = 47.254"
 
 save_
 


### PR DESCRIPTION
Example in several `_description_example.case` values used single quotes as part of nomenclature. Fixed by surrounding in double quote marks