### PR TITLE
add linked key _atom_sites_moment_Fourier.structure_id

### DIFF
--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -2369,7 +2369,7 @@ save_ATOM_SITES_MOMENT_FOURIER
     _definition.id                ATOM_SITES_MOMENT_FOURIER
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2024-05-17
+    _definition.update            2026-06-15
     _description.text
 ;
     Data items in the ATOM_SITES_MOMENT_FOURIER category record
@@ -2384,6 +2384,7 @@ save_ATOM_SITES_MOMENT_FOURIER
 ;
     _name.category_id             CIF_MAG_HEAD
     _name.object_id               ATOM_SITES_MOMENT_FOURIER
+    _category_key.name            '_atom_sites_moment_Fourier.structure_id'
 
 save_
 
@@ -2416,6 +2417,25 @@ save_atom_sites_moment_fourier.axes_description
      Extracted from Baudour & Sanquer
      [Acta Cryst. (1983), B39, 75-84].
 ;
+
+save_
+
+save_atom_sites_moment_fourier.structure_id
+
+    _definition.id                '_atom_sites_moment_Fourier.structure_id'
+    _definition.update            2026-06-15
+    _description.text
+;
+    A code identifying the crystallographic structure associated with the
+    magnetic modulations for the atom sites description.
+;
+    _name.category_id             atom_sites_moment_Fourier
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 

--- a/cif_mag.dic
+++ b/cif_mag.dic
@@ -11,7 +11,7 @@ data_CIF_MAG
     _dictionary.title             CIF_MAG
     _dictionary.class             Instance
     _dictionary.version           0.9.9
-    _dictionary.date              2026-05-28
+    _dictionary.date              2026-06-15
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/magnetic_dic/main/cif_mag.dic
     _dictionary.ddl_conformance   4.1.0
@@ -5009,7 +5009,7 @@ save_
        _atom_site_moment.Cartn* items, corrected and improved *_symmform
        descriptions. Created the atom_site_rotation category. (B Campbell)
 ;
-         0.9.9                    2026-05-28
+         0.9.9                    2026-06-15
 ;
        Changed several instances of "Jones-Faithful notation" to
        "Jones faithful notation".
@@ -5063,4 +5063,7 @@ save_
        because it is defined in cif_ms.dic.
 
        Improved clarity in transform_Pp_abc definitions.
+
+       2026-06-15: added _atom_sites_moment_fourier.structure_id as linked
+       key data name.
 ;


### PR DESCRIPTION
will close #101 

ATOM_SITES is described in cif_core as 

>The category of data items used to describe information which applies to all atom sites in a crystal structure.

ATOM_SITES_MOMENT_FOURIER is described in cif_mag as

> record details common to the magnetic modulations of atom sites in a modulated structure.

This adds a linked key `_atom_sites_moment_Fourier.structure_id`